### PR TITLE
refactor service layer

### DIFF
--- a/services/article_service.go
+++ b/services/article_service.go
@@ -10,21 +10,14 @@ import (
 // ハンドラ層が Article 構造体関連で呼び出したい処理
 
 // 指定IDの記事をデータベースから取得してくる
-func GetArticleService(articleID int) (models.Article, error) {
-	// TODO: sql.DB型を手に入れて変数dbに代入する
-	db, err := connectDB()
-	if err != nil {
-		return models.Article{}, err
-	}
-	defer db.Close()
-
+func (s *MyappService) GetArticleService(articleID int) (models.Article, error) {
 	// 1. repositories層の関数SelectArticleDetailで記事の詳細を取得
-	article, err := repositories.SelectArticleDetail(db, articleID)
+	article, err := repositories.SelectArticleDetail(s.db, articleID)
 	if err != nil {
 		return models.Article{}, err
 	}
 	// 2. repositorries層の関数SelectCommentListでコメント一覧を取得
-	commentList, err := repositories.SelectCommentList(db, articleID)
+	commentList, err := repositories.SelectCommentList(s.db, articleID)
 	if err != nil {
 		return models.Article{}, err
 	}
@@ -35,14 +28,8 @@ func GetArticleService(articleID int) (models.Article, error) {
 }
 
 // POST /article
-func PostArticleService(article models.Article) (models.Article, error) {
-	db, err := connectDB()
-	if err != nil {
-		log.Printf("データベースとの接続に失敗しました: %v", err)
-		return article, err
-	}
-	defer db.Close()
-	newArticle, err := repositories.InsertArticle(db, article)
+func (s *MyappService) PostArticleService(article models.Article) (models.Article, error) {
+	newArticle, err := repositories.InsertArticle(s.db, article)
 	if err != nil {
 		log.Printf("failed to exec insert article query: %v", err)
 		return newArticle, err
@@ -51,14 +38,8 @@ func PostArticleService(article models.Article) (models.Article, error) {
 }
 
 // GET /article/listハンドラに対するサービス層
-func GetArticleListService(page int) ([]models.Article, error) {
-	db, err := connectDB()
-	if err != nil {
-		return nil, err
-	}
-	defer db.Close()
-
-	articleArray, err := repositories.SelectArticleList(db, page)
+func (s *MyappService) GetArticleListService(page int) ([]models.Article, error) {
+	articleArray, err := repositories.SelectArticleList(s.db, page)
 	if err != nil {
 		log.Printf("データが取得できませんでした: %v", err)
 		return nil, err
@@ -68,15 +49,9 @@ func GetArticleListService(page int) ([]models.Article, error) {
 }
 
 // PostNiceHandlerでの使用を想定
-func PostNiceService(article models.Article) (models.Article, error) {
-	db, err := connectDB()
-	if err != nil {
-		log.Printf("データベースとの接続に失敗しました: %v", err)
-		return article, err
-	}
-
+func (s *MyappService) PostNiceService(article models.Article) (models.Article, error) {
 	articleID := article.ID // handlerが受け取った構造体からIdのみを取り出す
-	if err := repositories.UpdateNiceNum(db, articleID); err != nil {
+	if err := repositories.UpdateNiceNum(s.db, articleID); err != nil {
 		log.Printf("failed to update a number of nices %v", err)
 		return article, err
 	}

--- a/services/comment_service.go
+++ b/services/comment_service.go
@@ -9,14 +9,8 @@ import (
 
 // ハンドラ層が Comment 構造体関連で呼び出したい処理
 // PostCommenthandlerでの使用を想定
-func PostCommentService(comment models.Comment) (models.Comment, error) {
-	db, err := connectDB()
-	if err != nil {
-		log.Printf("failed to connect database %v", err)
-		return comment, err
-	}
-
-	insetedComment, err := repositories.InsertComment(db, comment)
+func (s *MyappService) PostCommentService(comment models.Comment) (models.Comment, error) {
+	insetedComment, err := repositories.InsertComment(s.db, comment)
 	if err != nil {
 		log.Printf("failed to insert new comment: %v", err)
 		return comment, err

--- a/services/service.go
+++ b/services/service.go
@@ -1,0 +1,12 @@
+package services
+
+import "database/sql"
+
+type MyappService struct {
+	db *sql.DB
+}
+
+// constructor
+func NewAppService(db *sql.DB) *MyappService {
+	return &MyappService{db: db}
+}


### PR DESCRIPTION
This pull request refactors the service layer to use a new `MyappService` struct, which encapsulates the database connection. This change improves the code structure by removing repeated database connection logic from individual service functions.

Key changes include:

### Introduction of `MyappService` struct:
* Added a new `MyappService` struct with a `db` field to hold the database connection. (`services/service.go`)
* Added a constructor function `NewAppService` to initialize `MyappService` instances. (`services/service.go`)

### Refactoring service functions:
* Updated `GetArticleService` to use the `MyappService` struct for database access. (`services/article_service.go`)
* Updated `PostArticleService` to use the `MyappService` struct for database access. (`services/article_service.go`)
* Updated `GetArticleListService` to use the `MyappService` struct for database access. (`services/article_service.go`)
* Updated `PostNiceService` to use the `MyappService` struct for database access. (`services/article_service.go`)
* Updated `PostCommentService` to use the `MyappService` struct for database access. (`services/comment_service.go`)